### PR TITLE
remove json.parse() for incoming recipe data

### DIFF
--- a/frontend/static/src/recipe-components/RecipeUpdate.js
+++ b/frontend/static/src/recipe-components/RecipeUpdate.js
@@ -138,7 +138,13 @@ class RecipeUpdate extends Component {
     axios.get(`${BASE_URL}/api/v1/recipes/${this.props.match.params.id}/`, {
       headers: {'Authorization': `Token ${JSON.parse(localStorage.getItem('current-user')).key}`}
     })
-    .then(response => this.setState({ingredients: JSON.parse(response.data.ingredients), instructions: JSON.parse(response.data.instructions), title: response.data.title, description: response.data.description, recipes: response.data}))
+    .then(response => this.setState({
+        ingredients: response.data.ingredients, 
+        instructions: response.data.instructions, 
+        title: response.data.title, 
+        description: response.data.description, 
+        recipes: response.data
+      }))
     .then(res => console.log(this.state))
     .catch(err => console.log(err));
   }


### PR DESCRIPTION
It's unnecessary to parse the data that comes from the API, because the current JSON format being used is essentially the same as a Javascript dictionary object. So the JSON format that the data is in, is also usable by the code without parsing. 

Closes #50 