### PR TITLE
add TokenAuthentication to default authentication classes

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -72,6 +72,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ]
 }
 


### PR DESCRIPTION
Per Django Rest Framework documentation on [authentication](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication), I need to have Token Authentication enabled in `settings.py`. 