### PR TITLE
remove proxy from package.json

### DIFF
--- a/frontend/static/package.json
+++ b/frontend/static/package.json
@@ -2,7 +2,6 @@
   "name": "static",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://127.0.0.1:8000/",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-regular-svg-icons": "^5.13.0",


### PR DESCRIPTION
This [proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/) was setup while in bootcamp, and now it looks like it was unnecessarily complicating things. As long as React has the appropriate slashes, this proxy is not needed.