### PR TITLE
Feat/render credential details

### DIFF
--- a/frontend/static/src/authentication/Login.js
+++ b/frontend/static/src/authentication/Login.js
@@ -16,6 +16,7 @@ class Login extends Component {
     this.state = {
       username: '',
       password: '',
+      badRequest: false, 
 
     }
 
@@ -48,7 +49,16 @@ class Login extends Component {
     axios.post(`${BASE_URL}/dj-rest-auth/login/`, this.state)
     .then(res => localStorage.setItem('current-user', JSON.stringify(res.data)))
     .then(res => this.captureLogin())
-    .catch(err => {console.log(err)})
+    .catch(err => {
+      console.log(err)
+      if (err.response.status === 400) {
+        this.setState({
+          badRequest: true,
+          badRequestResponse: err.response.data,
+        })
+      }
+      console.log(this.state)
+    })
   }
 
   render() {
@@ -61,6 +71,12 @@ class Login extends Component {
         <div className="card-body d-flex justify-content-center flex-column">
           <input className="form-group" type="text" value={this.state.username} autoComplete="username" placeholder="username" name="username" onChange={this.handleChange} />
           <input className="form-group" type="password" value={this.state.password} autoComplete="current-password" placeholder="password" name="password" onChange={this.handleChange} />
+          {this.state.badRequestResponse
+          ?
+          <small>{this.state.badRequestResponse.non_field_errors}</small>
+          :
+          null
+          }
         </div>
 
         <div className="d-flex justify-content-center">

--- a/frontend/static/src/authentication/Signup.js
+++ b/frontend/static/src/authentication/Signup.js
@@ -17,6 +17,7 @@ class Signup extends Component {
       email: '',
       password1: '',
       password2: '',
+      badRequest: false,
 
     }
 
@@ -51,7 +52,16 @@ class Signup extends Component {
       this.props.props.history.push('/profile/create/');
     })
     .then(res => this.captureLogin())
-    .catch(err => {console.log(err);})
+    .catch(err => {
+      console.log(err);
+      if (err.response.status === 400) {
+        this.setState({
+          badRequest: true,
+          badRequestResponse: err.response.data,
+        })
+      }
+      console.log('state', this.state)
+      })
 
   }
 
@@ -61,10 +71,39 @@ class Signup extends Component {
         <form method="post" type="submit" onSubmit={this.handleSignUp}>
           <div className="card-body d-flex justify-content-center flex-column">
             <input className="form-group" type="text" name="username" placeholder="username" value={this.state.username} onChange={this.handleChange}/>
+            {this.state.badRequest
+            ?
+              <small>{this.state.badRequestResponse['username']}</small>
+            :
+            null
+            }
             <input className="form-group" type="email" name="email" placeholder="email" autoComplete="email" value={this.state.email} onChange={this.handleChange} />
+            {this.state.badRequest 
+            ?
+              <small>{this.state.badRequestResponse['email']}</small>
+            :
+            null
+            }
             <input className="form-group" type="password" name="password1" placeholder="password" autoComplete="new-password" value={this.state.password1} onChange={this.handleChange} />
+            {this.state.badRequest
+            ?
+              <small>{this.state.badRequestResponse['password1']}</small>
+            :
+            null
+            }
             <input className="form-group" type="password" name="password2" placeholder="password" autoComplete="new-password" value={this.state.password2} onChange={this.handleChange} />
-            <small className="d-block">passwords must match</small> 
+            {this.state.badRequestResponse
+            ?
+              <small>{this.state.badRequestResponse['password2']}</small>
+            :
+            null
+            }
+            {this.state.badRequestResponse
+            ?
+            <small>{this.state.badRequestResponse.non_field_errors}</small>
+            :
+            null
+            }
           </div>
 
           <div  className="d-flex justify-content-center">


### PR DESCRIPTION
When a user tries to login with credentials that do not match a user in the database, render message returned by error: "Unable to log in with provided credentials".

When a new user attempts to register with credentials that don't meet the criteria required by [dj-rest-auth](https://github.com/iMerica/dj-rest-auth), render details of the error. 

The details for this will be things like: 
-    "There is already a user with that username"
-    "This password is too common"
-    "Passwords do not match"