### PR TITLE
Fix/follower following querysets

### DIFF
--- a/frontend/static/src/user-profile-components/ListFollowers.js
+++ b/frontend/static/src/user-profile-components/ListFollowers.js
@@ -23,7 +23,7 @@ class ListFollowers extends Component {
   }
 
   componentDidMount() {
-    axios.get(`${BASE_URL}/api/v1/profiles/followers/`, {
+    axios.get(`${BASE_URL}/api/v1/profiles/followers/${this.props.profile.owner.id}/`, {
       headers: {'Authorization': `Token ${JSON.parse(localStorage.getItem('current-user')).key}`}
     })
     .then(res => this.setState({followers: res.data}))

--- a/frontend/static/src/user-profile-components/ListFollowing.js
+++ b/frontend/static/src/user-profile-components/ListFollowing.js
@@ -25,7 +25,7 @@ class ListFollowing extends Component {
   }
 
   componentDidMount() {
-    axios.get(`${BASE_URL}/api/v1/profiles/following/`, {
+    axios.get(`${BASE_URL}/api/v1/profiles/following/${this.props.profile.owner.id}/`, {
       headers: {'Authorization': `Token ${JSON.parse(localStorage.getItem('current-user')).key}`}
     })
     .then(res => this.setState({connections: res.data}))

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -10,8 +10,8 @@ urlpatterns = [
     path('<int:pk>/', views.ProfileDetailView.as_view(), name='profile_detail'), 
     ## this endpoint contains the logged in user's profile
     path('user/', views.ProfileRetrieveUpdateView.as_view(), name='user_profile'),
-    path('followers/', views.FollowerListView.as_view(), name='list_followers'),
-    path('following/', views.FollowingListView.as_view(), name='list_following'),
+    path('followers/<int:pk>/', views.FollowerListView.as_view(), name='list_followers'),
+    path('following/<int:pk>/', views.FollowingListView.as_view(), name='list_following'),
     path('connections/', views.ConnectionListCreateAPIView.as_view(), name='connections'),
     path('connections/<int:pk>/', views.ConnectionRetrieveDestroyView.as_view(), name='remove_connections'),
 ]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -61,18 +61,17 @@ class FollowingListView(generics.ListAPIView):
 
     def get_queryset(self, **kwargs):
         if (self.kwargs):
-            user = self.kwargs['pk']
-        else:
-            return Connection.objects.filter(owner = self.request.user)
-        if user is not None:
-            queryset = queryset.filter(owner__profile__owner=user)
-            return queryset
-        else:
-            return Connection.objects.filter(owner = self.request.user)
+            owner = self.kwargs['pk']
+            return Connection.objects.filter(owner = owner)
 
 
 class FollowerListView(generics.ListAPIView):
     queryset = Connection.objects.all()
     serializer_class = ConnectionSerializer
     permission_classes = [permissions.IsAuthenticated]
+    
+    def get_queryset(self):
+        if (self.kwargs):
+            following = self.kwargs['pk']
+            return Connection.objects.filter(following = following)
  


### PR DESCRIPTION
This PR adds query_set filtering to two views, allowing the client to request appropriate data without having to filter it. This reduces the amount of data the server has to send and fixes a bug in one of the old query_set filters. 

- Add PK to URLConf for FollowingListView and FollowerListView.
- Add profile's owner id to get request in ListFollowing.js and ListFollowers.js.
- Add query_set filters to both FollowingListView and FollowerListView.

Closes #82 